### PR TITLE
Add OpenRouter LLM summarization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ Cases are stored as human-readable markdown in `memory/cases/CASE-NNNN-<slug>.md
 Each file has YAML frontmatter tracking status, severity, and timestamps, plus
 append-only evidence and decision logs.
 
+## LLM summarization (optional)
+
+By default Sherlock runs fully deterministic with no LLM calls. To enable
+AI-generated hypothesis text on case files, set your API key and pass
+`--summarize`:
+
+```bash
+export OPENAI_API_KEY=sk-...
+sherlock run --input telemetry.json --summarize
+```
+
+The key is read from the `OPENAI_API_KEY` environment variable. If it is
+absent when `--summarize` is used, Sherlock logs a warning and continues
+without summarization — it is never a hard failure.
+
 ## Running tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -55,17 +55,29 @@ append-only evidence and decision logs.
 ## LLM summarization (optional)
 
 By default Sherlock runs fully deterministic with no LLM calls. To enable
-AI-generated hypothesis text on case files, set your API key and pass
-`--summarize`:
+AI-generated hypothesis text on new case files, install the LLM extra and
+set your [OpenRouter](https://openrouter.ai) API key:
 
 ```bash
-export OPENAI_API_KEY=sk-...
+pip install -e ".[llm]"
+export OPENROUTER_API_KEY=sk-or-...
 sherlock run --input telemetry.json --summarize
 ```
 
-The key is read from the `OPENAI_API_KEY` environment variable. If it is
-absent when `--summarize` is used, Sherlock logs a warning and continues
-without summarization — it is never a hard failure.
+To pick a specific model (defaults to `openai/gpt-4o-mini`):
+
+```bash
+export OPENROUTER_MODEL=anthropic/claude-3-haiku
+sherlock run --input telemetry.json --summarize
+```
+
+OpenRouter gives access to models from OpenAI, Anthropic, Mistral, and
+others through a single key — useful for community testing without
+committing to a specific provider.
+
+If `OPENROUTER_API_KEY` is absent or the call fails, Sherlock logs a
+warning to stderr and continues without summarization — it is never a
+hard failure.
 
 ## Running tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ sherlock = "sherlock.cli:cli"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]
+llm = ["openai>=1.0"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/sherlock/cli.py
+++ b/sherlock/cli.py
@@ -17,7 +17,10 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
-def _run_cycle(input_path: str | Path | None) -> tuple[list[str], list[str]]:
+def _run_cycle(
+    input_path: str | Path | None,
+    summarize: bool = False,
+) -> tuple[list[str], list[str]]:
     """
     Run one detection cycle.
     Returns (transition_lines, steady_state_case_ids).
@@ -37,6 +40,11 @@ def _run_cycle(input_path: str | Path | None) -> tuple[list[str], list[str]]:
         timestamp = finding["timestamp"]
         transitions = tr.compute_transitions(case, finding, is_new)
         tr.update_case(case, finding, is_new, timestamp)
+        if summarize and is_new:
+            from sherlock import llm
+            hypothesis = llm.summarize(finding)
+            if hypothesis:
+                case["hypothesis"] = hypothesis
         mem.save_case(case)
         for t in transitions:
             line = rend.format_transition(t)
@@ -77,7 +85,8 @@ def cli() -> None:
 @click.option("--input", "input_path", default=None,
               help="Path to telemetry JSON file. Reads stdin if omitted.")
 @click.option("--no-llm", is_flag=True, default=False, hidden=True)
-@click.option("--summarize", is_flag=True, default=False, hidden=True)
+@click.option("--summarize", is_flag=True, default=False,
+              help="Generate hypothesis text via OpenRouter (requires OPENROUTER_API_KEY).")
 def run_cmd(input_path: str | None, no_llm: bool, summarize: bool) -> None:
     """Run one detection cycle against telemetry input."""
     if input_path is None and sys.stdin.isatty():
@@ -87,7 +96,7 @@ def run_cmd(input_path: str | None, no_llm: bool, summarize: bool) -> None:
             err=True,
         )
         sys.exit(1)
-    lines, _ = _run_cycle(input_path)
+    lines, _ = _run_cycle(input_path, summarize=summarize)
     for line in lines:
         click.echo(line)
 

--- a/sherlock/llm.py
+++ b/sherlock/llm.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+
+_BASE_URL = "https://openrouter.ai/api/v1"
+_DEFAULT_MODEL = "openai/gpt-4o-mini"
+
+
+def summarize(finding: dict[str, Any]) -> str | None:
+    """
+    Generate a one-sentence hypothesis for a case using OpenRouter.
+
+    Returns None (with a stderr warning) if the key is absent or the call fails.
+    Requires: pip install sherlock[llm]
+    """
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        print(
+            "Warning: OPENROUTER_API_KEY not set — skipping LLM summarization.",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print(
+            "Warning: openai package not installed — run `pip install sherlock[llm]`.",
+            file=sys.stderr,
+        )
+        return None
+
+    model = os.environ.get("OPENROUTER_MODEL", _DEFAULT_MODEL)
+    client = OpenAI(api_key=api_key, base_url=_BASE_URL)
+
+    prompt = (
+        f"In one sentence, explain why {finding['service']} {finding['metric']} "
+        f"is anomalous. Observed value: {finding['value']}. "
+        f"Threshold: {finding['threshold']}. Severity: {finding['severity']}."
+    )
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=80,
+        )
+        return response.choices[0].message.content.strip()
+    except Exception as exc:
+        print(f"Warning: LLM call failed ({exc}) — skipping summarization.", file=sys.stderr)
+        return None


### PR DESCRIPTION
Adds optional LLM summarization via OpenRouter.

- `sherlock/llm.py`: thin `summarize()` using OpenRouter's OpenAI-compatible API
- `--summarize` flag on `sherlock run` writes AI-generated hypothesis to new case files
- `OPENROUTER_API_KEY` and `OPENROUTER_MODEL` env vars; soft warning if absent
- `pip install sherlock[llm]` installs the `openai` package
- README updated with setup instructions

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWH83CzdY7ajzMj93WtHUJ)_